### PR TITLE
Move electron to Dev Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,9 +76,7 @@
     "tslint-loader": "^3.5.3",
     "typescript": "^2.3.3",
     "webpack": "^2.6.1",
-    "zone.js": "0.8.4"
-  },
-  "dependencies": {
+    "zone.js": "0.8.4",
     "electron": "^1.6.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ts-helpers": "^1.1.2",
     "tslint": "^5.3.2",
     "tslint-loader": "^3.5.3",
-    "typescript": "^2.3.3",
+    "typescript": "~2.3.3",
     "webpack": "^2.6.1",
     "zone.js": "0.8.4",
     "electron": "^1.6.11"


### PR DESCRIPTION
While using Electron-Packager I noticed my packaged app folder increasing dramatically after adding this module, so I started digging. Found that the electron package was getting bundled into the app even though I had electron listed in Dev Dependencies, digging further found it resided in this modules Dependencies, this was causing electron-packager to bundle it into the app, increasing the size by at least 132 MB. Simple fix though, just moved from Dependencies to Dev Dependencies and tested building and using the new version as a direct drop in replace on a couple apps I use this module in, and it works perfectly. Sizes are back to normal, so please consider my Pull-Request to help fellow users.

Side note: This is a fantastic module, thank you for your work!